### PR TITLE
Set default shell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,9 @@ env:
   # `BASE_URL` determines the website is served from, including CSS & JS assets
   # You may need to change this to `BASE_URL: ''`
   BASE_URL: /${{ github.event.repository.name }}
-
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read


### PR DESCRIPTION
This matches what's in [the EOF Cookbook deploy script](https://github.com/projectpythia-mystmd/eofs-cookbook/blob/main/.github/workflows/deploy.yml) and should resolve the deployment failure. I think this will ensure that the correct environment is used for the `myst build` command.